### PR TITLE
fix missing dependencies error

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "example-lifecycle": "spago --config examples/lifecycle/spago.dhall bundle-app --main Example.Lifecycle.Main --to examples/lifecycle/dist/example.js"
   },
   "devDependencies": {
-    "purescript-psa": "^0.8.0",
+    "purescript-psa": "^0.8.2",
     "rimraf": "^3.0.2",
-    "spago": "^0.18.1"
+    "spago": "^0.19.1"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,15 +1,9 @@
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/prepare-0.14/src/packages.dhall
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210304/packages.dhall sha256:c88151fe7c05f05290224c9c1ae4a22905060424fb01071b691d3fe2e5bad4ca
 
 in  upstream
   with event.version = "master"
   with event.repo = "https://github.com/thomashoneyman/purescript-event"
-
   with filterable.version = "master"
-  with filterable.repo = "https://github.com/thomashoneyman/purescript-filterable"
-
-  with freeap.version = "master"
-  with freeap.repo = "https://github.com/thomashoneyman/purescript-freeap"
-
-  with quickcheck-laws.version = "master"
-  with quickcheck-laws.repo = "https://github.com/thomashoneyman/purescript-quickcheck-laws"
+  with filterable.repo
+       = "https://github.com/thomashoneyman/purescript-filterable"

--- a/packages.dhall
+++ b/packages.dhall
@@ -4,6 +4,17 @@ let upstream =
 in  upstream
   with event.version = "master"
   with event.repo = "https://github.com/thomashoneyman/purescript-event"
+  with event.dependencies
+       =
+    [ "prelude"
+    , "console"
+    , "effect"
+    , "filterable"
+    , "nullable"
+    , "unsafe-reference"
+    , "js-timers"
+    , "now"
+    ]
   with filterable.version = "master"
   with filterable.repo
        = "https://github.com/thomashoneyman/purescript-filterable"

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210304/packages.dhall sha256:c88151fe7c05f05290224c9c1ae4a22905060424fb01071b691d3fe2e5bad4ca
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.0/packages.dhall sha256:710b53c085a18aa1263474659daa0ae15b7a4f453158c4f60ab448a6b3ed494e
 
 in  upstream
   with event.version = "master"


### PR DESCRIPTION
This PR appears to fix this error:

```
% spago build
[error] Failed to read the config. Error was:
[error] Error: Error while reading spago.dhall:

Explanation: a record is missing a required key.

The key missing is:

↳ dependencies

The keys in the record are:

↳ repo, version
```
I'm using Spago 0.19.1.

Dependencies copied from here: https://github.com/thomashoneyman/purescript-event/blob/master/bower.json
